### PR TITLE
Implement ConfigurationManager and refactor API key usage

### DIFF
--- a/AgentChat/OpenAIAssistantService.swift
+++ b/AgentChat/OpenAIAssistantService.swift
@@ -55,7 +55,7 @@ class OpenAIAssistantService {
     ]
     
     private var apiKey: String {
-        return KeychainService.shared.getAPIKey(for: "openai") ?? ""
+        return ConfigurationManager.shared.getAPIKey(for: .openAI) ?? ""
     }
     private var threadIds: [UUID: String] = [:] // Associa chat locali a thread OpenAI
     

--- a/AgentChat/Services/AnthropicService.swift
+++ b/AgentChat/Services/AnthropicService.swift
@@ -32,14 +32,14 @@ class AnthropicService: ChatServiceProtocol {
     }
     
     func validateConfiguration() async throws -> Bool {
-        guard KeychainService.shared.hasAPIKey(for: "anthropic") else {
+        guard ConfigurationManager.shared.hasAPIKey(for: .claude) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         return true
     }
     
     private func sendMessageToAnthropic(message: String, model: String) async throws -> String {
-        guard let apiKey = KeychainService.shared.getAPIKey(for: "anthropic") else {
+        guard let apiKey = ConfigurationManager.shared.getAPIKey(for: .claude) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         

--- a/AgentChat/Services/ConfigurationManager.swift
+++ b/AgentChat/Services/ConfigurationManager.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Centralized configuration manager handling API keys securely via KeychainService.
+class ConfigurationManager {
+    static let shared = ConfigurationManager()
+    private let keychain = KeychainService.shared
+
+    private init() {}
+
+    // MARK: - Generic Identifier Based Methods
+    func setAPIKey(_ key: String, for identifier: String) -> Bool {
+        keychain.saveAPIKey(key, for: identifier)
+    }
+
+    func getAPIKey(for identifier: String) -> String? {
+        keychain.getAPIKey(for: identifier)
+    }
+
+    func removeAPIKey(for identifier: String) -> Bool {
+        keychain.deleteAPIKey(for: identifier)
+    }
+
+    func hasAPIKey(for identifier: String) -> Bool {
+        keychain.hasAPIKey(for: identifier)
+    }
+
+    func clearAllAPIKeys() -> Bool {
+        keychain.clearAllAPIKeys()
+    }
+
+    func getAllStoredProviders() -> [String] {
+        keychain.getAllStoredProviders()
+    }
+
+    // MARK: - AgentType Convenience Methods
+    func setAPIKey(_ key: String, for agent: AgentType) -> Bool {
+        setAPIKey(key, for: agent.rawValue.lowercased())
+    }
+
+    func getAPIKey(for agent: AgentType) -> String? {
+        getAPIKey(for: agent.rawValue.lowercased())
+    }
+
+    func removeAPIKey(for agent: AgentType) -> Bool {
+        removeAPIKey(for: agent.rawValue.lowercased())
+    }
+
+    func hasAPIKey(for agent: AgentType) -> Bool {
+        hasAPIKey(for: agent.rawValue.lowercased())
+    }
+}

--- a/AgentChat/Services/CustomProviderService.swift
+++ b/AgentChat/Services/CustomProviderService.swift
@@ -42,7 +42,7 @@ class CustomProviderService: ChatServiceProtocol {
     
     func sendMessage(message: String, provider: AssistantProvider, model: String) async throws -> String {
         // For custom providers, we'll try to use a generic OpenAI-compatible format
-        guard let apiKey = KeychainService.shared.getAPIKey(for: provider.id) else {
+        guard let apiKey = ConfigurationManager.shared.getAPIKey(for: provider.id) else {
             throw ChatServiceError.missingAPIKey("API key missing for provider: \(provider.name)")
         }
         

--- a/AgentChat/Services/GrokService.swift
+++ b/AgentChat/Services/GrokService.swift
@@ -32,14 +32,14 @@ class GrokService: ChatServiceProtocol {
     }
     
     func validateConfiguration() async throws -> Bool {
-        guard KeychainService.shared.hasAPIKey(for: "grok") else {
+        guard ConfigurationManager.shared.hasAPIKey(for: .grok) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         return true
     }
     
     private func sendMessageToGrok(message: String, model: String) async throws -> String {
-        guard let apiKey = KeychainService.shared.getAPIKey(for: "grok") else {
+        guard let apiKey = ConfigurationManager.shared.getAPIKey(for: .grok) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         

--- a/AgentChat/Services/LocalAssistantConfiguration.swift
+++ b/AgentChat/Services/LocalAssistantConfiguration.swift
@@ -94,23 +94,23 @@ class LocalAssistantConfiguration: ObservableObject {
     // MARK: - API Key Management
     func hasValidAPIKey(for provider: AssistantProvider) -> Bool {
         guard provider.apiKeyRequired else { return true }
-        // Use provider type as keychain ID to match what services expect
-        return KeychainService.shared.hasAPIKey(for: provider.type.rawValue)
+        // Use provider type as identifier for ConfigurationManager
+        return ConfigurationManager.shared.hasAPIKey(for: provider.type.rawValue)
     }
     
     func setAPIKey(_ key: String, for provider: AssistantProvider) -> Bool {
-        // Use provider type as keychain ID to match what services expect
-        return KeychainService.shared.saveAPIKey(key, for: provider.type.rawValue)
+        // Use provider type as identifier for ConfigurationManager
+        return ConfigurationManager.shared.setAPIKey(key, for: provider.type.rawValue)
     }
     
     func getAPIKey(for provider: AssistantProvider) -> String? {
-        // Use provider type as keychain ID to match what services expect
-        return KeychainService.shared.getAPIKey(for: provider.type.rawValue)
+        // Use provider type as identifier for ConfigurationManager
+        return ConfigurationManager.shared.getAPIKey(for: provider.type.rawValue)
     }
     
     func removeAPIKey(for provider: AssistantProvider) -> Bool {
-        // Use provider type as keychain ID to match what services expect
-        return KeychainService.shared.deleteAPIKey(for: provider.type.rawValue)
+        // Use provider type as identifier for ConfigurationManager
+        return ConfigurationManager.shared.removeAPIKey(for: provider.type.rawValue)
     }
     
     // MARK: - Validation
@@ -191,7 +191,7 @@ class LocalAssistantConfiguration: ObservableObject {
     func resetToDefaults() {
         userDefaults.removeObject(forKey: customProvidersKey)
         userDefaults.removeObject(forKey: disabledProvidersKey)
-        KeychainService.shared.clearAllAPIKeys()
+        ConfigurationManager.shared.clearAllAPIKeys()
         
         customProviders.removeAll()
         setupDefaultProviders()

--- a/AgentChat/Services/MistralService.swift
+++ b/AgentChat/Services/MistralService.swift
@@ -32,14 +32,14 @@ class MistralService: ChatServiceProtocol {
     }
     
     func validateConfiguration() async throws -> Bool {
-        guard KeychainService.shared.hasAPIKey(for: "mistral") else {
+        guard ConfigurationManager.shared.hasAPIKey(for: .mistral) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         return true
     }
     
     private func sendMessageToMistral(message: String, model: String) async throws -> String {
-        guard let apiKey = KeychainService.shared.getAPIKey(for: "mistral") else {
+        guard let apiKey = ConfigurationManager.shared.getAPIKey(for: .mistral) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         

--- a/AgentChat/Services/N8NService.swift
+++ b/AgentChat/Services/N8NService.swift
@@ -12,7 +12,6 @@ class N8NService: ChatServiceProtocol {
     static let shared = N8NService()
     
     private var sessionIds: [String: String] = [:] // chatId -> sessionId
-    private let keychainService = KeychainService.shared
     
     private init() {}
     
@@ -252,17 +251,17 @@ class N8NService: ChatServiceProtocol {
     
     func saveAPIKey(_ apiKey: String, for workflowId: String) {
         let key = "n8n_workflow_\(workflowId)"
-        _ = keychainService.saveAPIKey(apiKey, for: key)
+        _ = ConfigurationManager.shared.setAPIKey(apiKey, for: key)
     }
     
     func getAPIKey(for workflowId: String) -> String? {
         let key = "n8n_workflow_\(workflowId)"
-        return keychainService.getAPIKey(for: key)
+        return ConfigurationManager.shared.getAPIKey(for: key)
     }
     
     func removeAPIKey(for workflowId: String) {
         let key = "n8n_workflow_\(workflowId)"
-        _ = keychainService.deleteAPIKey(for: key)
+        _ = ConfigurationManager.shared.removeAPIKey(for: key)
     }
     
     // MARK: - Private Methods

--- a/AgentChat/Services/N8NWorkflowManager.swift
+++ b/AgentChat/Services/N8NWorkflowManager.swift
@@ -15,7 +15,6 @@ class N8NWorkflowManager: ObservableObject {
     @Published var errorMessage: String?
     
     private let userDefaultsKey = "n8n_workflows"
-    private let keychainService = KeychainService.shared
     
     // MARK: - Singleton
     static let shared = N8NWorkflowManager()
@@ -202,17 +201,17 @@ class N8NWorkflowManager: ObservableObject {
     /// Salva/rimuove API key per workflow che richiedono autenticazione
     func saveAPIKey(_ apiKey: String, for workflowId: String) {
         let key = "n8n_workflow_\(workflowId)"
-        _ = keychainService.saveAPIKey(apiKey, for: key)
+        _ = ConfigurationManager.shared.setAPIKey(apiKey, for: key)
     }
     
     func getAPIKey(for workflowId: String) -> String? {
         let key = "n8n_workflow_\(workflowId)"
-        return keychainService.getAPIKey(for: key)
+        return ConfigurationManager.shared.getAPIKey(for: key)
     }
     
     func removeAPIKey(for workflowId: String) {
         let key = "n8n_workflow_\(workflowId)"
-        _ = keychainService.deleteAPIKey(for: key)
+        _ = ConfigurationManager.shared.removeAPIKey(for: key)
     }
     
     // MARK: - Private Methods

--- a/AgentChat/Services/OpenAIService.swift
+++ b/AgentChat/Services/OpenAIService.swift
@@ -32,14 +32,14 @@ class OpenAIService: ChatServiceProtocol {
     }
     
     func validateConfiguration() async throws -> Bool {
-        guard KeychainService.shared.hasAPIKey(for: "openai") else {
+        guard ConfigurationManager.shared.hasAPIKey(for: .openAI) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         return true
     }
     
     private func sendMessageToOpenAI(message: String, model: String) async throws -> String {
-        guard let apiKey = KeychainService.shared.getAPIKey(for: "openai") else {
+        guard let apiKey = ConfigurationManager.shared.getAPIKey(for: .openAI) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         

--- a/AgentChat/Services/PerplexityService.swift
+++ b/AgentChat/Services/PerplexityService.swift
@@ -32,14 +32,14 @@ class PerplexityService: ChatServiceProtocol {
     }
     
     func validateConfiguration() async throws -> Bool {
-        guard KeychainService.shared.hasAPIKey(for: "perplexity") else {
+        guard ConfigurationManager.shared.hasAPIKey(for: .perplexity) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         return true
     }
     
     private func sendMessageToPerplexity(message: String, model: String) async throws -> String {
-        guard let apiKey = KeychainService.shared.getAPIKey(for: "perplexity") else {
+        guard let apiKey = ConfigurationManager.shared.getAPIKey(for: .perplexity) else {
             throw ChatServiceError.missingAPIKey(providerName)
         }
         

--- a/AgentChat/Views/APIKeyConfigView.swift
+++ b/AgentChat/Views/APIKeyConfigView.swift
@@ -262,10 +262,10 @@ struct APIKeyConfigView: View {
         let keychainId = provider.type.rawValue
         
         // Store the existing key if any
-        let existingKey = KeychainService.shared.getAPIKey(for: keychainId)
+        let existingKey = ConfigurationManager.shared.getAPIKey(for: keychainId)
         
         // Temporarily save the new key for testing with the correct provider type ID
-        let tempSaved = KeychainService.shared.saveAPIKey(trimmedKey, for: keychainId)
+        let tempSaved = ConfigurationManager.shared.setAPIKey(trimmedKey, for: keychainId)
         
         guard tempSaved else {
             testResult = .failure("Errore nel salvare temporaneamente l'API key")
@@ -307,10 +307,10 @@ struct APIKeyConfigView: View {
         // Restore the original key or remove the temporary one
         if let existingKey = existingKey {
             // Restore the original key
-            KeychainService.shared.saveAPIKey(existingKey, for: keychainId)
+            ConfigurationManager.shared.setAPIKey(existingKey, for: keychainId)
         } else {
             // Remove the temporary key since there was no existing key
-            KeychainService.shared.deleteAPIKey(for: keychainId)
+            ConfigurationManager.shared.removeAPIKey(for: keychainId)
         }
         
         isTestingConnection = false

--- a/AgentChat/Views/NewChatView.swift
+++ b/AgentChat/Views/NewChatView.swift
@@ -246,7 +246,7 @@ struct NewChatView: View {
         if let selectedWorkflow {
             if selectedWorkflow.requiresAuthentication {
                 // Verifica se c'è una API key per n8n nel keychain
-                return KeychainService.shared.getAPIKey(for: "n8n_\(selectedWorkflow.id)") != nil
+                return ConfigurationManager.shared.getAPIKey(for: "n8n_\(selectedWorkflow.id)") != nil
             }
             return true
         }


### PR DESCRIPTION
## Summary
- create `ConfigurationManager` wrapper for key storage
- update service classes to use the new manager
- update UI and configuration helpers accordingly
- keep assistant service working with the new key retrieval

## Testing
- `swiftc @sources.txt -o build/out` *(fails: no such module 'Security')*

------
https://chatgpt.com/codex/tasks/task_e_68767da7a77c8326870c5d9aef7cd679