### PR TITLE
Implement local chat persistence

### DIFF
--- a/AgentChat/Models/Chat.swift
+++ b/AgentChat/Models/Chat.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 // MARK: - Chat
-class Chat: Identifiable, ObservableObject, Hashable {
+class Chat: Identifiable, ObservableObject, Hashable, Codable {
     let id: UUID
     @Published var messages: [Message]
     let agentType: AgentType
@@ -37,5 +37,35 @@ class Chat: Identifiable, ObservableObject, Hashable {
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+    }
+
+    // MARK: - Codable
+    enum CodingKeys: String, CodingKey {
+        case id
+        case messages
+        case agentType
+        case provider
+        case selectedModel
+        case n8nWorkflow
+    }
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        messages = try container.decode([Message].self, forKey: .messages)
+        agentType = try container.decode(AgentType.self, forKey: .agentType)
+        provider = try container.decodeIfPresent(AssistantProvider.self, forKey: .provider)
+        selectedModel = try container.decodeIfPresent(String.self, forKey: .selectedModel)
+        n8nWorkflow = try container.decodeIfPresent(N8NWorkflow.self, forKey: .n8nWorkflow)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(messages, forKey: .messages)
+        try container.encode(agentType, forKey: .agentType)
+        try container.encodeIfPresent(provider, forKey: .provider)
+        try container.encodeIfPresent(selectedModel, forKey: .selectedModel)
+        try container.encodeIfPresent(n8nWorkflow, forKey: .n8nWorkflow)
     }
 }

--- a/AgentChat/Models/Message.swift
+++ b/AgentChat/Models/Message.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // MARK: - Message
-struct Message: Identifiable, Equatable {
+struct Message: Identifiable, Equatable, Codable {
     let id: UUID
     let content: String
     let isUser: Bool

--- a/AgentChat/Services/ChatPersistenceManager.swift
+++ b/AgentChat/Services/ChatPersistenceManager.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+// MARK: - Chat Persistence Manager
+class ChatPersistenceManager {
+    static let shared = ChatPersistenceManager()
+
+    private let fileURL: URL
+
+    private init() {
+        let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        fileURL = directory.appendingPathComponent("chats.json")
+    }
+
+    // Save chats to disk
+    func saveChats(_ chats: [Chat]) {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            let data = try encoder.encode(chats)
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            print("Errore nel salvataggio delle chat: \(error)")
+        }
+    }
+
+    // Load chats from disk
+    func loadChats() -> [Chat] {
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let chats = try JSONDecoder().decode([Chat].self, from: data)
+            // Sort messages chronologically within each chat
+            chats.forEach { chat in
+                chat.messages.sort { $0.timestamp < $1.timestamp }
+            }
+            return chats
+        } catch {
+            return []
+        }
+    }
+
+    // Export chats to a temporary JSON file
+    func exportChats(_ chats: [Chat]) -> URL? {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            let data = try encoder.encode(chats)
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("agentchat_export.json")
+            try data.write(to: url, options: .atomic)
+            return url
+        } catch {
+            return nil
+        }
+    }
+
+    // Import chats from a JSON file and replace current ones
+    func importChats(from url: URL) -> [Chat]? {
+        do {
+            let data = try Data(contentsOf: url)
+            let chats = try JSONDecoder().decode([Chat].self, from: data)
+            return chats
+        } catch {
+            return nil
+        }
+    }
+}

--- a/AgentChat/Services/ChatService.swift
+++ b/AgentChat/Services/ChatService.swift
@@ -16,6 +16,10 @@ import SwiftUI
 // MARK: - Chat Manager
 class ChatManager: ObservableObject {
     @Published var chats: [Chat] = []
+
+    init() {
+        chats = ChatPersistenceManager.shared.loadChats()
+    }
     
     func createNewChat(with provider: AssistantProvider, model: String?, workflow: N8NWorkflow? = nil) {
         let agentType: AgentType = {
@@ -45,15 +49,30 @@ class ChatManager: ObservableObject {
         )
         
         chats.append(newChat)
+        ChatPersistenceManager.shared.saveChats(chats)
     }
-    
+
     func deleteChat(at offsets: IndexSet) {
         chats.remove(atOffsets: offsets)
+        ChatPersistenceManager.shared.saveChats(chats)
     }
-    
+
     func addMessage(to chat: Chat, message: Message) {
         if let index = chats.firstIndex(where: { $0.id == chat.id }) {
             chats[index].messages.append(message)
+            ChatPersistenceManager.shared.saveChats(chats)
+        }
+    }
+
+    // MARK: - Import/Export
+    func exportChats() -> URL? {
+        ChatPersistenceManager.shared.exportChats(chats)
+    }
+
+    func importChats(from url: URL) {
+        if let imported = ChatPersistenceManager.shared.importChats(from: url) {
+            chats = imported
+            ChatPersistenceManager.shared.saveChats(chats)
         }
     }
 }

--- a/AgentChat/Views/ChatListView.swift
+++ b/AgentChat/Views/ChatListView.swift
@@ -66,7 +66,7 @@ struct ChatListView: View {
                 }
             }
         .sheet(isPresented: $showingSettings) {
-            SettingsView(workflowManager: workflowManager)
+            SettingsView(workflowManager: workflowManager, chatManager: chatService)
         }
         .onAppear {
             workflowManager.loadWorkflows()


### PR DESCRIPTION
## Summary
- add `Codable` conformance to `Chat` and `Message`
- implement `ChatPersistenceManager` for saving and loading chat history
- persist chats in `ChatManager` and support import/export
- pass `ChatManager` to `SettingsView` and add conversation export/import options

## Testing
- `swiftc --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68767da5ec548326a84e496c22afaaf5