### PR TITLE
Persist sent messages with ChatManager

### DIFF
--- a/AgentChat/Services/ChatService.swift
+++ b/AgentChat/Services/ChatService.swift
@@ -82,9 +82,11 @@ class ChatManager: ObservableObject {
 
     /// Aggiunge un nuovo messaggio a una chat esistente.
     func addMessage(to chat: Chat, message: Message) {
-        if let index = chats.firstIndex(where: { $0.id == chat.id }) {
-            chats[index].messages.append(message)
-            CoreDataPersistenceManager.shared.saveOrUpdateChat(chat: chats[index])
+        // Use the chat model's logic to append the message and update metadata
+        chat.addMessage(message)
+
+        if chats.firstIndex(where: { $0.id == chat.id }) != nil {
+            CoreDataPersistenceManager.shared.saveOrUpdateChat(chat: chat)
         }
     }
 

--- a/AgentChat/Views/ChatDetailView.swift
+++ b/AgentChat/Views/ChatDetailView.swift
@@ -266,8 +266,8 @@ struct ChatDetailView: View {
         
         let userMsg = Message(id: UUID(), content: trimmed, isUser: true, timestamp: Date())
         
-        // Aggiungi il messaggio alla chat con analisi e memorizzazione
-        chat.addMessage(userMsg)
+        // Aggiungi il messaggio alla chat e persisti tramite il manager
+        ChatManager.shared.addMessage(to: chat, message: userMsg)
         
         inputText = ""
         errorMessage = nil
@@ -324,9 +324,9 @@ struct ChatDetailView: View {
             }
             
             let assistantMessage = Message(id: UUID(), content: responseText, isUser: false, timestamp: Date())
-            
-            // Aggiungi il messaggio dell'assistente con analisi e memorizzazione
-            chat.addMessage(assistantMessage)
+
+            // Aggiungi il messaggio dell'assistente e persisti tramite il manager
+            ChatManager.shared.addMessage(to: chat, message: assistantMessage)
             
         } catch {
             if let idx = chat.messages.firstIndex(where: { $0.id == placeholderId }) {


### PR DESCRIPTION
## Summary
- ensure ChatManager updates chat model when adding messages
- use ChatManager in ChatDetailView when sending user and assistant messages

## Testing
- `xcodebuild -project AgentChat.xcodeproj -scheme AgentChat -destination 'platform=iOS Simulator,name=iPhone 16' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783715bca083269f7d666ed05181cf